### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # eslint-config-namely
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/12d3aaac8de745ffb2239389e3424562)](https://app.codacy.com/gh/namely/eslint-config-namely/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/12d3aaac8de745ffb2239389e3424562)](https://app.codacy.com/gh/namely/eslint-config-namely/dashboard)
 
 Namely's shared ESLint config (based on [Airbnb's config](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb)).
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.